### PR TITLE
feat: add korean stock support

### DIFF
--- a/src/app/api/kr-stock-data/route.ts
+++ b/src/app/api/kr-stock-data/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const symbol = searchParams.get('symbol') || '005930';
+
+  try {
+    const stooqUrl = `https://stooq.com/q/d/l/?s=${symbol}.kr&i=d`;
+    const res = await fetch(stooqUrl, { cache: 'no-store' });
+    if (!res.ok) {
+      throw new Error(`Failed to fetch CSV: ${res.status}`);
+    }
+    const text = await res.text();
+    const lines = text.trim().split('\n');
+    lines.shift();
+    const data = lines.map((line) => {
+      const [date, open, high, low, close, volume] = line.split(',');
+      return {
+        time: Math.floor(new Date(date).getTime() / 1000).toString(),
+        open: Number(open),
+        high: Number(high),
+        low: Number(low),
+        close: Number(close),
+        volume: Number(volume),
+      };
+    });
+    const latest = data[data.length - 1];
+    const prev = data[data.length - 2] || latest;
+
+    let companyName = symbol;
+    try {
+      const summaryRes = await fetch(
+        `https://api.finance.naver.com/service/itemSummary.nhn?itemcode=${symbol}`,
+        { headers: { 'User-Agent': 'Mozilla/5.0' }, cache: 'no-store' }
+      );
+      if (summaryRes.ok) {
+        const summary = await summaryRes.json();
+        companyName = summary?.name || summary?.nm || companyName;
+      }
+    } catch (e) {
+      console.warn('Failed to fetch company name from Naver:', e);
+    }
+
+    return NextResponse.json({
+      symbol,
+      currentPrice: latest.close,
+      change: latest.close - prev.close,
+      changePercent: ((latest.close - prev.close) / prev.close) * 100,
+      data,
+      meta: {
+        companyName,
+        currency: 'KRW',
+        exchangeName: 'KRX',
+        lastUpdated: new Date().toISOString(),
+      },
+    });
+  } catch (error) {
+    console.error('KR stock data error:', error);
+    return NextResponse.json(
+      {
+        error: 'Failed to fetch Korean stock data',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/stock.ts
+++ b/src/app/api/stock.ts
@@ -4,11 +4,14 @@ import apiClient from './client';
 // 주식 데이터 조회
 export const getStockData = async (symbol: string): Promise<StockInfo> => {
   try {
+    const isKorean = /^\d{6}$/.test(symbol);
+    const endpoint = isKorean ? '/api/kr-stock-data' : '/api/stock-data';
+
     // SSR에서는 직접 Next.js API route 호출
     if (typeof window === 'undefined') {
       const baseUrl =
         process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3000';
-      const url = `${baseUrl}/api/stock-data?symbol=${symbol}`;
+      const url = `${baseUrl}${endpoint}?symbol=${symbol}`;
       const response = await fetch(url);
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
@@ -17,7 +20,7 @@ export const getStockData = async (symbol: string): Promise<StockInfo> => {
     }
 
     // 클라이언트에서는 axios 사용
-    const response = await apiClient.get(`/api/stock-data`, {
+    const response = await apiClient.get(endpoint, {
       params: { symbol },
     });
     return response.data;

--- a/src/app/components/StockHeader.tsx
+++ b/src/app/components/StockHeader.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { checkBackendHealth } from '@/app/api';
-import { formatUSD } from '@/app/lib/utils';
+import { formatPrice } from '@/app/lib/utils';
 import { StockInfo } from '@/types/stock';
 import { useEffect, useState } from 'react';
 
@@ -61,7 +61,7 @@ export default function StockHeader({
 
           <div className="flex items-center gap-4 mt-2">
             <span className="text-2xl lg:text-3xl font-semibold">
-              {formatUSD(stockInfo.currentPrice)}
+              {formatPrice(stockInfo.currentPrice, stockInfo.meta.currency)}
             </span>
             <div
               className={`flex items-center gap-2 px-3 py-1 rounded-lg ${
@@ -72,7 +72,9 @@ export default function StockHeader({
             >
               <span className="text-sm lg:text-base font-medium">
                 {stockInfo.change >= 0 ? '↑' : '↓'}
-                {Math.abs(stockInfo.change).toFixed(2)}
+                {Math.abs(stockInfo.change).toFixed(
+                  stockInfo.meta.currency === 'KRW' ? 0 : 2
+                )}
               </span>
               <span className="text-sm lg:text-base">
                 ({stockInfo.changePercent >= 0 ? '+' : ''}

--- a/src/app/components/calculator/CalculationResults.tsx
+++ b/src/app/components/calculator/CalculationResults.tsx
@@ -1,14 +1,16 @@
 'use client';
 
-import { formatCurrency, formatUSD } from '@/app/lib/utils';
+import { formatCurrency, formatPrice } from '@/app/lib/utils';
 import { CalculationResult } from '@/types/stock';
 
 interface CalculationResultsProps {
   calculation: CalculationResult;
+  currency: string;
 }
 
 export default function CalculationResults({
   calculation,
+  currency,
 }: CalculationResultsProps) {
   const isProfit = calculation.profit >= 0;
 
@@ -55,14 +57,14 @@ export default function CalculationResults({
         <ResultCard
           label="구매 가능했던 주식"
           value={`${calculation.shares.toFixed(2)}주`}
-          subtext={`@${formatUSD(calculation.pastPrice)}`}
+          subtext={`@${formatPrice(calculation.pastPrice, currency)}`}
         />
 
         <ResultCard
           label="현재 가치"
           value={formatCurrency(calculation.currentValue)}
           valueColor="text-white"
-          subtext={`@${formatUSD(calculation.currentPrice)}`}
+          subtext={`@${formatPrice(calculation.currentPrice, currency)}`}
           isBold
         />
 

--- a/src/app/components/calculator/CalculatorInput.tsx
+++ b/src/app/components/calculator/CalculatorInput.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { formatUSD } from '@/app/lib/utils';
+import { formatPrice } from '@/app/lib/utils';
 
 interface CalculatorInputProps {
   investDate: string;
   investAmount: number;
   currentPrice: number;
+  currency: string;
   minDate: string;
   maxDate: string;
   exchangeRate?: number;
@@ -19,6 +20,7 @@ export default function CalculatorInput({
   investDate,
   investAmount,
   currentPrice,
+  currency,
   minDate,
   maxDate,
   exchangeRate,
@@ -64,36 +66,38 @@ export default function CalculatorInput({
         </label>
         <input
           type="text"
-          value={formatUSD(currentPrice)}
+          value={formatPrice(currentPrice, currency)}
           readOnly
           className="w-full px-3 py-2 bg-gray-800/50 border border-gray-700 rounded-lg
                      text-gray-400 cursor-not-allowed"
         />
       </div>
 
-      <div>
-        <label className="block text-sm font-medium text-gray-400 mb-2">
-          환율 (KRW/USD)
-        </label>
-        <div className="relative">
-          <input
-            type="text"
-            value={
-              exchangeRateLoading
-                ? '로딩 중...'
-                : `₩${exchangeRate?.toLocaleString() || '1,350'}`
-            }
-            readOnly
-            className="w-full px-3 py-2 bg-gray-800/50 border border-gray-700 rounded-lg
-                       text-gray-400 cursor-not-allowed"
-          />
-          {exchangeRateLoading && (
-            <div className="absolute right-3 top-1/2 transform -translate-y-1/2">
-              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-500"></div>
-            </div>
-          )}
+      {currency === 'USD' && (
+        <div>
+          <label className="block text-sm font-medium text-gray-400 mb-2">
+            환율 (KRW/USD)
+          </label>
+          <div className="relative">
+            <input
+              type="text"
+              value={
+                exchangeRateLoading
+                  ? '로딩 중...'
+                  : `₩${exchangeRate?.toLocaleString() || '1,350'}`
+              }
+              readOnly
+              className="w-full px-3 py-2 bg-gray-800/50 border border-gray-700 rounded-lg
+                         text-gray-400 cursor-not-allowed"
+            />
+            {exchangeRateLoading && (
+              <div className="absolute right-3 top-1/2 transform -translate-y-1/2">
+                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-blue-500"></div>
+              </div>
+            )}
+          </div>
         </div>
-      </div>
+      )}
 
       <div className="flex items-end">
         <button

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -2,7 +2,7 @@
 
 import { useAuth } from '@/app/hooks/useAuth';
 import { useCalculationHistory } from '@/app/hooks/useCalculationHistory';
-import { formatCurrency, formatUSD } from '@/app/lib/utils';
+import { formatCurrency, formatPrice } from '@/app/lib/utils';
 import { CalculationHistory } from '@/lib/supabase';
 import { useState } from 'react';
 
@@ -122,14 +122,22 @@ function HistoryCard({ item, onDelete, isDeleting }: HistoryCardProps) {
           <p className="text-sm text-gray-400">투자 금액</p>
           <p className="font-semibold">{formatCurrency(item.invest_amount)}</p>
         </div>
-        <div>
-          <p className="text-sm text-gray-400">구매 가격</p>
-          <p className="font-semibold">{formatUSD(item.past_price)}</p>
-        </div>
-        <div>
-          <p className="text-sm text-gray-400">현재 가격</p>
-          <p className="font-semibold">{formatUSD(item.current_price)}</p>
-        </div>
+        {(() => {
+          const isKorean = /^\d{6}$/.test(item.symbol);
+          const currency = isKorean ? 'KRW' : 'USD';
+          return (
+            <>
+              <div>
+                <p className="text-sm text-gray-400">구매 가격</p>
+                <p className="font-semibold">{formatPrice(item.past_price, currency)}</p>
+              </div>
+              <div>
+                <p className="text-sm text-gray-400">현재 가격</p>
+                <p className="font-semibold">{formatPrice(item.current_price, currency)}</p>
+              </div>
+            </>
+          );
+        })()}
         <div>
           <p className="text-sm text-gray-400">손익</p>
           <p

--- a/src/app/lib/utils.ts
+++ b/src/app/lib/utils.ts
@@ -8,12 +8,13 @@ export function formatCurrency(value: number): string {
   }).format(value);
 }
 
-export function formatUSD(value: number): string {
-  return new Intl.NumberFormat('en-US', {
+export function formatPrice(value: number, currency: string): string {
+  const isKRW = currency === 'KRW';
+  return new Intl.NumberFormat(isKRW ? 'ko-KR' : 'en-US', {
     style: 'currency',
-    currency: 'USD',
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
+    currency,
+    minimumFractionDigits: isKRW ? 0 : 2,
+    maximumFractionDigits: isKRW ? 0 : 2,
   }).format(value);
 }
 


### PR DESCRIPTION
## Summary
- add `kr-stock-data` API route using free Stooq and Naver data
- detect Korean symbols and format prices per currency
- handle KRW flows in regret calculator and UI

## Testing
- `pnpm lint` *(fails: Config (unnamed): Key "plugins": This appears to be in eslintrc format)*
- `pnpm test` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689c59b3437083298f78439067a1db67